### PR TITLE
Checagem do cache retornar array vazio

### DIFF
--- a/Gateway/Services/CacheService.php
+++ b/Gateway/Services/CacheService.php
@@ -54,7 +54,7 @@ class CacheService implements ZipCodeServiceInterface
     public function getCacheData()
     {
         $cacheData = $this->cacheType->load(ApiSearchType::CACHE_TAG);
-        return unserialize($cacheData);
+        return $cacheData ? unserialize($cacheData) : [];
     }
 
     /**


### PR DESCRIPTION
A partir do PHP 8.0 (Magento 2.4.3 >) ficou depreciado a conversão automática de "false" para "array".